### PR TITLE
Change initial value for GVal to lowspeed slew mode

### DIFF
--- a/AstroEQ-Firmware/AstroEQ/commands.c
+++ b/AstroEQ-Firmware/AstroEQ/commands.c
@@ -47,7 +47,7 @@ void Commands_init(unsigned long _eVal, byte _gVal){
         cmd.FVal[i] = CMD_DISABLED;
         cmd.jVal[i] = 0x800000; //Current position, 0x800000 is the centre
         cmd.IVal[i] = cmd.siderealIVal[i]; //Recieved Speed will be set by :I command.
-        cmd.GVal[i] = 0; //Mode recieved from :G command
+        cmd.GVal[i] = CMD_GVAL_LOWSPEED_SLEW; //Mode recieved from :G command
         cmd.HVal[i] = 0; //Value recieved from :H command
         cmd.eVal[i] = _eVal; //version number
         cmd.gVal[i] = _gVal; //High speed scalar


### PR DESCRIPTION
The initial value for GVal was still set to 0, change that to the new macro CMD_GVAL_LOWSPEED_SLEW to match the initial value for the highspeed flag.

The effect was a :J command would make an initial lowspeed forward slew change to highspeed forward slew, which would make one highspeed tick, then stop.